### PR TITLE
Bugfix: CSP no longer blocks upload requests to CDN enabled scrivito tenants

### DIFF
--- a/config/initializers/secure_headers.rb
+++ b/config/initializers/secure_headers.rb
@@ -10,6 +10,7 @@ Rails.application.config.after_initialize do |app|
       https://*.scrvt.com
       https://scrivito-public-cdn.s3-eu-west-1.amazonaws.com
       https://scrivito-upload.s3-eu-west-1.amazonaws.com
+      https://scrivito-upload.s3-accelerate.amazonaws.com
     )
 
     data = %w(data:)


### PR DESCRIPTION
Without this directive it's not possible, to upload images using the browser. The following error message is shown:

> Refused to connect to 'https://scrivito-upload.s3-accelerate.amazonaws.com/' because it violates the following Content Security Policy directive: "default-src 'self' *.googleapis.com *.gstatic.com *.scrivito.com *.scrvt.com scrivito-public-cdn.s3-eu-west-1.amazonaws.com scrivito-upload.s3-eu-west-1.amazonaws.com". Note that 'connect-src' was not explicitly set, so 'default-src' is used as a fallback.

Reported by @agessler 